### PR TITLE
Dependency Cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [{ include = "evocarshare" }]
 [tool.poetry.dependencies]
 python = ">=3.11,<4.0"
 haversine = "^2.8.1"
-aiohttp = "^3.11.6"
+aiohttp = "^3.10.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [{ include = "evocarshare" }]
 [tool.poetry.dependencies]
 python = ">=3.11,<4.0"
 haversine = "^2.8.1"
-aiohttp = "^3.10.0"
+aiohttp = "^3.6.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"


### PR DESCRIPTION
The dependencies are currently needlessly strict. This PR lowers the required version for `aiohttp`, to be more inclusive